### PR TITLE
createアクションの定義・投稿完了フォームの作成

### DIFF
--- a/app/assets/stylesheets/modules/_new.scss
+++ b/app/assets/stylesheets/modules/_new.scss
@@ -1,4 +1,4 @@
-// registrations/new.html.haml及び、sessions/new.html.hamlのクラスを共有しています
+// registrations/new.html.haml、sessions/new.html.haml、posts/new.html.hamlのクラスを共有しています
 
 .contents {
   width: 100%;
@@ -25,7 +25,10 @@
       border: 1px solid #d8d8d8;
       border-radius: 5px;
     }
-    .signup-botton {
+    .text-form {
+      width: 100%;
+    }
+    .action-botton {
       background-color: #57c3e9;
       border-radius: 20px;
       color: white;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,2 +1,4 @@
 class PostsController < ApplicationController
-
+  def index
+  end
+end

--- a/app/controllers/toppages_controller.rb
+++ b/app/controllers/toppages_controller.rb
@@ -2,4 +2,17 @@ class ToppagesController < ApplicationController
   def index
     @posts = Post.all
   end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    Post.create(post_params)
+  end
+
+  private
+  def post_params
+    params.require(:post).permit(:name, :image, :text)
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,3 @@
 class Post < ApplicationRecord
+  validates :text, presence: true
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -25,4 +25,4 @@
         %br/
         = f.password_field :password_confirmation, autocomplete: "new-password"
       .actions
-        = f.submit "Sign up", class: 'signup-botton'
+        = f.submit "Sign up", class: 'action-botton'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -17,4 +17,4 @@
           = f.label :remember_me
           = f.check_box :remember_me
       .actions
-        = f.submit "Log in", class: 'signup-botton'
+        = f.submit "Log in", class: 'action-botton'

--- a/app/views/posts/create.html.haml
+++ b/app/views/posts/create.html.haml
@@ -1,0 +1,6 @@
+= render partial: "layouts/header"
+
+.contents
+  .success
+    %h3 投稿が完了しました。
+    %a.btn{:href => "/"} 投稿一覧へ戻る

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -1,0 +1,10 @@
+= render partial: "layouts/header"
+
+.contents
+  .container
+    = form_with(model: @post, local: true) do |form|
+      %h3 投稿する
+      = form.text_field :name, placeholder: "Nickname"
+      = form.text_field :image, placeholder: "Image Url"
+      = form.text_area :text, placeholder: "text", rows: "10", class: 'text-form'
+      = form.submit "SEND", class: 'action-botton'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   get 'toppages/index'
   root "toppages#index"
-  resources :posts, only: [:index]
+  resources :posts, only: [:index, :new, :create]
 end


### PR DESCRIPTION
What
ルーティングにcreateアクションを定義
ストパラ定義
モデルに空入力禁止
投稿完了ビュー作成

Why
投稿内容をDBに保存する為