### PR TITLE
ユーザー情報編集

### DIFF
--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -15,6 +15,14 @@
       line-height: 41px;
       float: left;
       margin-left: 100px;
+      display: flex;
+      &__name {
+        a {
+          text-decoration: none;
+          font-weight: bold;
+          color: #57c3e9;
+        }
+      }
     }
     &__right {
       text-align: right;

--- a/app/assets/stylesheets/modules/_new.scss
+++ b/app/assets/stylesheets/modules/_new.scss
@@ -1,4 +1,5 @@
-// registrations/new.html.haml、sessions/new.html.haml、posts/new.html.hamlのクラスを共有しています
+// registrations/new.html.haml、registrations/edit.html.haml
+// sessions/new.html.haml、posts/new.html.hamlのクラスを共有しています
 
 .contents {
   width: 100%;

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,36 +1,36 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      %br/
-      %em
-        = @minimum_password_length
-        characters minimum
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+= render partial: "layouts/header"
+
+.contents
+  .container
+    %h2
+      Edit #{resource_name.to_s.humanize}
+    = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+      = render "devise/shared/error_messages", resource: resource
+      .field
+        = f.label :email
+        %br/
+        = f.email_field :email, autofocus: true, autocomplete: "email"
+      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+        %div
+          Currently waiting confirmation for: #{resource.unconfirmed_email}
+      .field
+        = f.label :password
+        %i (leave blank if you don't want to change it)
+        %br/
+        = f.password_field :password, autocomplete: "new-password"
+        - if @minimum_password_length
+          %br/
+          %em
+            = @minimum_password_length
+            characters minimum
+      .field
+        = f.label :password_confirmation
+        %br/
+        = f.password_field :password_confirmation, autocomplete: "new-password"
+      .field
+        = f.label :current_password
+        %i (we need your current password to confirm your changes)
+        %br/
+        = f.password_field :current_password, autocomplete: "current-password"
+      .actions
+        = f.submit "Update", class: 'action-botton'

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -3,7 +3,7 @@
     .header__bar__left
       ようこそ！
       - if user_signed_in?
-        = "#{current_user.nickname}さん"
+        = link_to "#{current_user.nickname}さん", edit_user_registration_path, method: :get
     .header__bar__right
       %ul.header-item
       - if user_signed_in?

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -3,7 +3,8 @@
     .header__bar__left
       ようこそ！
       - if user_signed_in?
-        = link_to "#{current_user.nickname}さん", edit_user_registration_path, method: :get
+        .header__bar__left__name
+          = link_to "#{current_user.nickname}さん", edit_user_registration_path, method: :get
     .header__bar__right
       %ul.header-item
       - if user_signed_in?


### PR DESCRIPTION
What
・deviseで実装したユーザー情報編集機能を調整
→ログイン後、headerのニックネームからユーザー情報編集ページに移動できるようにした
→ユーザー情報編集ページのSCSS編集

Why
・UIの向上及び利便性を図る為