### PR TITLE
ゲストユーザーを削除させない

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,2 @@
+class RegistrationsController < ApplicationController
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,2 +1,3 @@
 class RegistrationsController < ApplicationController
+  before_action :check_guest, only: :destroy
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,3 +1,10 @@
-class RegistrationsController < ApplicationController
+class RegistrationsController < Devise::RegistrationsController
   before_action :check_guest, only: :destroy
+
+  def check_guest
+    if resource.email == 'guest@example.com'
+      redirect_to root_path, alert: 'ゲストユーザーは削除できません。'
+    end
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
+
   get 'toppages/index'
   root "toppages#index"
   resources :posts do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: 'users/registrations'
+    registrations: 'registrations'
   }
-
   get 'toppages/index'
   root "toppages#index"
   resources :posts do


### PR DESCRIPTION
What
動作確認の利便性・セキュリティの観点からゲストユーザーの削除を禁止する

Why
上記理由の為