### PR TITLE
ゲストユーザーの情報を編集させない

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,13 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  def check_guest
+    email = resource&.email || params[:user][:email].downcase
+    if email == 'guest@example.com'
+      redirect_to root_path, alert: 'ゲストユーザーの変更・削除はできません'
+    end
+  end
+
   private
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,2 @@
+class PasswordsController < ApplicationController
+end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,2 +1,3 @@
-class PasswordsController < ApplicationController
+class PasswordsController < Devise::ApplicationController
+before_action :check_guest, only: :create
 end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,3 +1,4 @@
 class PasswordsController < Devise::ApplicationController
-before_action :check_guest, only: :create
+  before_action :check_guest, only: :create
+
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,9 +1,9 @@
 class RegistrationsController < Devise::RegistrationsController
-  before_action :check_guest, only: :destroy
+  before_action :check_guest, only: %i[update destroy]
 
   def check_guest
     if resource.email == 'guest@example.com'
-      redirect_to root_path, alert: 'ゲストユーザーは削除できません。'
+      redirect_to root_path, alert: 'ゲストユーザーの変更・削除できません。'
     end
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,10 +1,4 @@
 class RegistrationsController < Devise::RegistrationsController
   before_action :check_guest, only: %i[update destroy]
 
-  def check_guest
-    if resource.email == 'guest@example.com'
-      redirect_to root_path, alert: 'ゲストユーザーの変更・削除できません。'
-    end
-  end
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: 'registrations'
+    passwords: 'registrations'
   }
   get 'toppages/index'
   root "toppages#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
-    registrations: 'registrations'
-    passwords: 'registrations'
+    registrations: 'registrations',
+    passwords: 'passwords'
   }
   get 'toppages/index'
   root "toppages#index"


### PR DESCRIPTION
What
ゲストユーザーがログインしている時、ユーザー情報編集ページ及び、パスワードメール再設定にて行う
アカウント情報の編集作業を不可とした
また、削除と編集処理のリファクタリングを行った

Why
セキュリティ面の強化及び、コードの読み易さ向上の為