### PR TITLE
制約と誓約3

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :posts
+  validates :nickname, presence: true
   validates :nickname, uniqueness: true
 
   def self.guest

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :posts
+  validates :nickname, uniqueness: true
 
   def self.guest
     find_or_create_by!(email: 'guest@example.com') do |user|

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -20,7 +20,7 @@
           %li.header-bar-item
             = link_to "新規投稿", new_post_path, method: :get
           %li.header-bar-item
-            = link_to "ログアウト", destroy_user_session_path, method: :delete
+            = link_to "ログアウト", destroy_user_session_path, method: :delete ,data: {confirm: "ログアウトします。よろしいですか？"}
         - else
           %li.header-bar-item
             = link_to "ログイン", new_user_session_path, method: :get

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,6 +12,5 @@
     = render 'layouts/notifications'
     -# %script{:src => "https://cdn.jsdelivr.net/npm/bubbly-bg@1.0.0/dist/bubbly-bg.js"}
     -# :javascript
-    -#   bubbly({
-    -#   });
+    -#   bubbly();
     = yield

--- a/app/views/toppages/_container.html.haml
+++ b/app/views/toppages/_container.html.haml
@@ -14,7 +14,7 @@
           - if user_signed_in? && post.user_id == current_user.id
             = link_to edit_post_path(post.id), method: :get, class:"edit-actions-btn" do
               編集
-            = link_to post_path(post.id), method: :delete, class:"edit-actions-btn" do
+            = link_to post_path(post.id), method: :delete, class:"edit-actions-btn" ,data: {confirm: "投稿を削除します。よろしいですか？"} do
               削除
   %ul.debug-tool
     %h4.debug-tool-text

--- a/app/views/toppages/_container.html.haml
+++ b/app/views/toppages/_container.html.haml
@@ -37,5 +37,5 @@
         .tooltiptext
           ゲストユーザー以外削除します
     %li.debug-tool-item
-      = link_to "アカウント削除", user_registration_path, method: :delete ,data: {confirm: "ゲストユーザー以外のアカウントを削除します。よろしいですか？"}
+      = link_to "アカウント削除", user_registration_path, method: :delete
     %hr

--- a/app/views/toppages/_container.html.haml
+++ b/app/views/toppages/_container.html.haml
@@ -37,5 +37,5 @@
         .tooltiptext
           ゲストユーザー以外削除します
     %li.debug-tool-item
-      = link_to "アカウント削除", user_registration_path, method: :delete
+      = link_to "アカウント削除", user_registration_path, method: :delete ,data: {confirm: "ゲストユーザー以外のアカウントを削除します。よろしいですか？"}
     %hr


### PR DESCRIPTION
What
・新規登録時におけるニックネーム制約条件の追加（空白と一意性）
・投稿削除及びログアウト時に確認ダイアログを表示させた

Why
・登録条件の厳密化
・操作性の向上