### PR TITLE
リダイレクト処理にアラートを出す

### DIFF
--- a/app/views/toppages/_container.html.haml
+++ b/app/views/toppages/_container.html.haml
@@ -29,6 +29,7 @@
           未ログイン状態でご確認下さい
     %li.debug-tool-item
       = link_to "新規投稿", new_post_path, method: :get, :onclick => "clickEvent()"
+        - unless user_signed_in?
     %hr
     %h4.debug-tool-text
       %i.fas.fa-user.fa-2x

--- a/app/views/toppages/_container.html.haml
+++ b/app/views/toppages/_container.html.haml
@@ -28,7 +28,7 @@
         .tooltiptext
           未ログイン状態でご確認下さい
     %li.debug-tool-item
-      = link_to "新規投稿", new_post_path, method: :get
+      = link_to "新規投稿", new_post_path, method: :get, :onclick => "clickEvent()"
     %hr
     %h4.debug-tool-text
       %i.fas.fa-user.fa-2x

--- a/app/views/toppages/_container.html.haml
+++ b/app/views/toppages/_container.html.haml
@@ -30,6 +30,10 @@
     %li.debug-tool-item
       = link_to "新規投稿", new_post_path, method: :get, :onclick => "clickEvent()"
         - unless user_signed_in?
+        :javascript
+          function clickEvent (){
+          alert('');
+          }
     %hr
     %h4.debug-tool-text
       %i.fas.fa-user.fa-2x

--- a/app/views/toppages/_container.html.haml
+++ b/app/views/toppages/_container.html.haml
@@ -32,7 +32,7 @@
         - unless user_signed_in?
         :javascript
           function clickEvent (){
-          alert('');
+          alert('ログイン状態ではない為、リダイレクトします。');
           }
     %hr
     %h4.debug-tool-text


### PR DESCRIPTION
What
アプリ検証ツール一覧の新規投稿にて、ログインされていない状態の場合は
リダイレクト処理が行われるが、ログイン状態に応じてポップアップメッセージを表示する様にした。

Why
処理の可視化の為
![リダイレクト処理の可視化](https://user-images.githubusercontent.com/67348810/92297586-c5657d00-ef7b-11ea-9b8f-7fbd7bde9574.gif)
