### PR TITLE
Postまいぐれ修正

### DIFF
--- a/db/migrate/20200815015531_create_posts.rb
+++ b/db/migrate/20200815015531_create_posts.rb
@@ -3,7 +3,6 @@ class CreatePosts < ActiveRecord::Migration[6.0]
     create_table :posts do |t|
       t.string :name
       t.string :text
-      t.text :image
       t.timestamps
     end
   end

--- a/db/migrate/20200820005827_add_user_id_to_posts.rb
+++ b/db/migrate/20200820005827_add_user_id_to_posts.rb
@@ -1,5 +1,5 @@
 class AddUserIdToPosts < ActiveRecord::Migration[6.0]
   def change
-    add_column :posts, :user_id, :integer
+    add_column :posts, :user_id, :references, null: false, foreign_key: true
   end
 end

--- a/db/migrate/20200820005827_add_user_id_to_posts.rb
+++ b/db/migrate/20200820005827_add_user_id_to_posts.rb
@@ -1,5 +1,5 @@
 class AddUserIdToPosts < ActiveRecord::Migration[6.0]
   def change
-    add_column :posts, :user_id, :references, null: false, foreign_key: true
+    add_reference :posts, :user, null: false, foreign_key: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,26 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_06_001745) do
-
-  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["post_id"], name: "index_likes_on_post_id"
-    t.index ["user_id"], name: "index_likes_on_user_id"
-  end
-
-  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
-    t.string "text"
-    t.text "image"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.integer "user_id"
-    t.integer "likes_count"
-  end
+ActiveRecord::Schema.define(version: 2020_08_15_001201) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -39,11 +20,8 @@ ActiveRecord::Schema.define(version: 2020_09_06_001745) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "nickname"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "likes", "posts"
-  add_foreign_key "likes", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_15_001201) do
+ActiveRecord::Schema.define(version: 2020_09_06_001745) do
+
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["post_id"], name: "index_likes_on_post_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name"
+    t.string "text"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.integer "likes_count"
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -20,8 +39,12 @@ ActiveRecord::Schema.define(version: 2020_08_15_001201) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "nickname"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "likes", "posts"
+  add_foreign_key "likes", "users"
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
What
以下のマイグレーションファイルを修正しました。
・postsのimageカラムを削除
・postsのuser_idカラムをintegerからreference型に修正

Why
後でメモするための備忘録

■参考にしたサイト
https://pikawaka.com/rails/migration#add_column

■rails db:rollbackを使う
rails db:rollback STEP=x と入力するとxの数字だけファイルをdownにする

■修正後、エラーが起きる（Error: Duplicate column name ''"、カラムの重複、SQL）
一旦ファイルを空にして　→rails db:migrate
→また試してもエラーが起きる
一旦DBリセットする　→rake db:migrate:reset

それで今回は外部キーを追加したいので
add referencesを使って修正する

add_reference :posts, :user, null: false, foreign_key: true

マイグレーションファイルの編集や削除などでオプションが多々あるので色々試してみるのも○。